### PR TITLE
[bugfix] Disable toggle keys when typing in a textbox

### DIFF
--- a/scripts/components/ChoresHelpers.lua
+++ b/scripts/components/ChoresHelpers.lua
@@ -99,7 +99,7 @@ end
 -- @return (boolean)
 function IsDefaultScreen()
   local active_screen = TheFrontEnd:GetActiveScreen()
-  return active_screen and active_screen.name and active_screen.name.find and active_screen.name:find("HUD") ~= nil
+  return active_screen and active_screen.name and active_screen.name.find and active_screen.name:find("HUD") ~= nil and not ThePlayer.HUD:HasInputFocus()
 end
 
 --- Reload setting.


### PR DESCRIPTION
Newer versions of the game have a crafting menu with a textbox to search for items:

![image](https://user-images.githubusercontent.com/4441174/171027483-49a28a8d-c409-4e4e-a683-ecb31d4c5826.png)

When typing in this textbox and the letter key is bound to the settings/chores widget, the settings/chores widget will pop up in addition to the letter being typed. This is pretty much never what the user wants to do.

With this change, when you press one of the toggle keys (for example, "V") in the textbox, it won't pop up the mod settings/chores widget.